### PR TITLE
Upgrade to node 0.3 and a question

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/gif.node
+/build/
+.lock-wscript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "gif",
-   "version": "1.0.0",
+   "version": "2.0.0",
    "main": "gif",
    "description": "A C++ module for node-js that converts RGB and RGBA buffers to a GIF images (in memory).",
    "keywords": [
@@ -33,7 +33,7 @@
        "tests": "tests"
    },
    "engines": {
-       "node": ">=0.1.93"
+       "node": ">=0.3.0"
    },
    "scripts": {
        "install": "node-waf configure build"

--- a/src/buffer_compat.cpp
+++ b/src/buffer_compat.cpp
@@ -1,0 +1,58 @@
+#include <node.h>
+#include <node_buffer.h>
+#include <node_version.h>
+#include <v8.h>
+#include "buffer_compat.h"
+
+
+#if NODE_MINOR_VERSION < 3
+
+
+char *BufferData(node::Buffer *b) {
+  return b->data();
+}
+
+
+size_t BufferLength(node::Buffer *b) {
+  return b->length();
+}
+
+
+char *BufferData(v8::Local<v8::Object> buf_obj) {
+  v8::HandleScope scope;
+  node::Buffer *buf = node::ObjectWrap::Unwrap<node::Buffer>(buf_obj);
+  return buf->data();
+}
+
+
+size_t BufferLength(v8::Local<v8::Object> buf_obj) {
+  v8::HandleScope scope;
+  node::Buffer *buf = node::ObjectWrap::Unwrap<node::Buffer>(buf_obj);
+  return buf->length();
+}
+
+#else // NODE_VERSION
+
+
+char *BufferData(node::Buffer *b) {
+  return node::Buffer::Data(b->handle_);
+}
+
+
+size_t BufferLength(node::Buffer *b) {
+  return node::Buffer::Length(b->handle_);
+}
+
+
+char *BufferData(v8::Local<v8::Object> buf_obj) {
+  v8::HandleScope scope;
+  return node::Buffer::Data(buf_obj);
+}
+
+
+size_t BufferLength(v8::Local<v8::Object> buf_obj) {
+  v8::HandleScope scope;
+  return node::Buffer::Length(buf_obj);
+}
+
+#endif // NODE_VERSION

--- a/src/buffer_compat.h
+++ b/src/buffer_compat.h
@@ -1,0 +1,15 @@
+#ifndef buffer_compat_h
+#define buffer_compat_h
+
+#include <node.h>
+#include <node_buffer.h>
+#include <v8.h>
+
+char *BufferData(node::Buffer *b);
+size_t BufferLength(node::Buffer *b);
+
+char *BufferData(v8::Local<v8::Object> buf_obj);
+size_t BufferLength(v8::Local<v8::Object> buf_obj);
+
+
+#endif  // buffer_compat_h

--- a/src/common.h
+++ b/src/common.h
@@ -38,6 +38,7 @@ struct encode_request {
     char *gif;
     int gif_len;
     char *error;
+    char *buf_data;
 };
 
 #endif

--- a/src/dynamic_gif_stack.h
+++ b/src/dynamic_gif_stack.h
@@ -48,7 +48,7 @@ public:
     DynamicGifStack(buffer_type bbuf_type);
     ~DynamicGifStack();
 
-    v8::Handle<v8::Value> Push(node::Buffer *buf, int x, int y, int w, int h);
+    v8::Handle<v8::Value> Push(unsigned char *buf_data, size_t buf_len, int x, int y, int w, int h);
     v8::Handle<v8::Value> Dimensions();
     v8::Handle<v8::Value> GifEncodeSync();
 

--- a/src/gif.h
+++ b/src/gif.h
@@ -8,7 +8,6 @@
 
 class Gif : public node::ObjectWrap {
     int width, height;
-    node::Buffer *data;
     buffer_type buf_type;
     Color transparency_color;
 
@@ -17,7 +16,7 @@ class Gif : public node::ObjectWrap {
 
 public:
     static void Initialize(v8::Handle<v8::Object> target);
-    Gif(node::Buffer *ddata, int wwidth, int hheight, buffer_type bbuf_type);
+    Gif(int wwidth, int hheight, buffer_type bbuf_type);
     v8::Handle<v8::Value> GifEncodeSync();
     void SetTransparencyColor(unsigned char r, unsigned char g, unsigned char b);
 

--- a/wscript
+++ b/wscript
@@ -1,6 +1,6 @@
 import Options
 from os import unlink, symlink, popen
-from os.path import exists 
+from os.path import exists
 
 srcdir = "."
 blddir = "build"
@@ -21,7 +21,7 @@ def configure(conf):
 def build(bld):
   obj = bld.new_task_gen("cxx", "shlib", "node_addon")
   obj.target = "gif"
-  obj.source = "src/common.cpp src/utils.cpp src/palette.cpp src/quantize.cpp src/gif_encoder.cpp src/gif.cpp src/dynamic_gif_stack.cpp src/animated_gif.cpp src/async_animated_gif.cpp src/module.cpp"
+  obj.source = "src/common.cpp src/utils.cpp src/palette.cpp src/quantize.cpp src/gif_encoder.cpp src/gif.cpp src/dynamic_gif_stack.cpp src/animated_gif.cpp src/async_animated_gif.cpp src/module.cpp src/buffer_compat.cpp"
   obj.uselib = "GIF"
   obj.cxxflags = ["-D_FILE_OFFSET_BITS=64", "-D_LARGEFILE_SOURCE"]
 


### PR DESCRIPTION
Hello,

This changes the buffer code to work with node 0.3.  I took nearly all of the changes verbatim from ryah's similar commit to node-png.

The reason I started looking into it was because I'm trying to generate different sized transparent gifs.  Is there an easy/performant way to generate empty images?

Thanks,
Michael
